### PR TITLE
Batch Download: Automatically adjust the size of the watermark 

### DIFF
--- a/R/mod_indvExpPatVisits_fct_plot.R
+++ b/R/mod_indvExpPatVisits_fct_plot.R
@@ -109,11 +109,11 @@ fnIndvExplVisits <- function(
     extra_aval_vars <- c("ATM","ATPT")
     if(most_avals_per_visit > 1 & any(extra_aval_vars %in% colnames(plot_dat))){
       # Grab first available variable that exists and could explain why their are extra avals
-      avals_by <- sym(extra_aval_vars[extra_aval_vars %in% colnames(plot_dat)][1])
+      avals_by <<- sym(extra_aval_vars[extra_aval_vars %in% colnames(plot_dat)][1])
       if(avals_by == "ATM") {
         plot_dat <- plot_dat %>% mutate(ATM = as.POSIXct(paste("1970-01-01",ATM)))
       }
-      # if discrete atpt, use color aesthetic 
+      # if discrete atpt, use color aesthetic automatically
       if(avals_by == "ATPT"){
         lb_plot <- lb_plot + 
           suppressWarnings(
@@ -149,6 +149,7 @@ fnIndvExplVisits <- function(
       }
       
     } else { # no color by variable in legend or hover text
+      avals_by <<- ""
       lb_plot <- lb_plot + 
         suppressWarnings(geom_point(na.rm = TRUE, 
           aes(text = paste0(AVISIT,
@@ -175,8 +176,9 @@ fnIndvExplVisits <- function(
         
         # Smaller watermark
         annotate("text", x = Inf, y = -Inf, label = "tidyCDISC: PROOF ONLY",
-                 hjust=1.1, vjust=-3.3, col="white", cex=20,
-                 fontface = "bold", alpha = 0.8)
+                 hjust=1.1, vjust=-3.3, col="white", fontface = "bold", alpha = 0.8,
+                 cex = ifelse(avals_by == "" | rlang::is_empty(avals_by),16,12)
+                 )
       
     }
     


### PR DESCRIPTION
First, since tidyCDISC is much longer than "IDEA", this needed to be adjusted anyhow. But also created conditional size element depending on colour aesthetic by another variable. Only effects work for pdf outputs. HTML automatically sized. 

![image](https://user-images.githubusercontent.com/17878953/88691794-4ef77480-d0cb-11ea-9c92-9d57835d5133.png)

![image](https://user-images.githubusercontent.com/17878953/88691856-6171ae00-d0cb-11ea-85e2-48f5b3d7cf0d.png)
